### PR TITLE
Fix button className forwarding

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -43,11 +43,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
     return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
+        <Comp
+          className={cn(buttonVariants({ variant, size }), className)}
+          ref={ref}
+          {...props}
+        />
     )
   }
 )


### PR DESCRIPTION
## Summary
- fix Button component so custom classes apply correctly

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` font)*

------
https://chatgpt.com/codex/tasks/task_e_68439a11c07c832bb46f9b4f952f8109